### PR TITLE
Example conf to repro segfault per rsyslog/rsyslog#1920

### DIFF
--- a/rsyslog-i1920.conf
+++ b/rsyslog-i1920.conf
@@ -1,0 +1,34 @@
+# Example conf originally posted to rsyslog/rsyslog#1920
+
+$ActionFileDefaultTemplate RSYSLOG_FileFormat
+$RepeatedMsgReduction off
+$WorkDirectory /var/spool/rsyslog
+
+module(
+    load="builtin:omfile"
+    fileOwner="syslog"
+    fileGroup="adm"
+    dirOwner="syslog"
+    dirGroup="adm"
+    fileCreateMode="0640"
+    dirCreateMode="0755"
+)
+
+module(load="imudp")
+module(load="imptcp")
+
+input(type="imudp" port="514" ruleset="receiver-standard-rules")
+input(type="imptcp" port="514" KeepAlive="on" ruleset="receiver-standard-rules")
+
+ruleset(name="receiver-standard-rules") {
+
+    if ($!origin!hostname == "") then {
+        continue
+    }
+
+    action(
+        name="test-messages"
+        type="omfile"
+        file="/var/log/rsyslog_testing.log"
+    )
+}


### PR DESCRIPTION
This conf file was posted to rsyslog/rsyslog#1920 to reproduce the segfault encountered when checking for a blank JSON message property.